### PR TITLE
Cavalier stat fix

### DIFF
--- a/data/cargo drone.txt
+++ b/data/cargo drone.txt
@@ -3,7 +3,7 @@ ship "Cargo Drone"
 	thumbnail "thumbnail/cargo drone thumbnail"
 	attributes
 		category "Drone"
-		"cost" 80000
+		"cost" 120000
 		"hull" 400
 		"automaton" 1
 		"mass" 20

--- a/data/cavalier.txt
+++ b/data/cavalier.txt
@@ -13,7 +13,7 @@ ship "Cavalier"
 		"heat dissipation" .65
 		"fuel capacity" 700
 		"cargo space" 30
-		"outfit space" 310
+		"outfit space" 300
 		"weapon capacity" 125 # 25 per gun port if no turrets fitted.
 		"engine capacity" 90
 		weapon


### PR DESCRIPTION
- Given Cavalier its intended outfit space of 300 (was 310).
- Increased Cargo Drone cost to 120k (was 80k).